### PR TITLE
Feature/threads

### DIFF
--- a/src/main/kotlin/no/nav/bidrag/cucumber/Environment.kt
+++ b/src/main/kotlin/no/nav/bidrag/cucumber/Environment.kt
@@ -1,6 +1,10 @@
 package no.nav.bidrag.cucumber
 
+import no.nav.bidrag.cucumber.cloud.FellesEgenskaperService
+import no.nav.bidrag.cucumber.cloud.arbeidsflyt.PrefiksetJournalpostIdForHendelse
+import no.nav.bidrag.cucumber.model.BidragCucumberSingletons
 import no.nav.bidrag.cucumber.model.CucumberTestsDto
+import no.nav.bidrag.cucumber.model.TestMessagesHolder
 import org.slf4j.LoggerFactory
 
 internal object Environment {
@@ -13,7 +17,7 @@ internal object Environment {
     @JvmStatic
     private val INGRESS_FOR_APP = ThreadLocal<MutableMap<String, String>>()
 
-    internal val alleIngresserForApper: String
+    private val alleIngresserForApper: String
         get() = fetchPropertyOrEnvironment(INGRESSES_FOR_APPS) ?: CUCUMBER_TESTS.get()?.fetchIngressesForAppsAsString() ?: ""
 
     val clientId: String get() = fetchPropertyOrEnvironment(AZURE_APP_CLIENT_ID) ?: "unknown-AZURE_APP_CLIENT_ID"
@@ -78,12 +82,19 @@ internal object Environment {
         cucumberTestsDto.warningLogDifferences()
     }
 
+    /**
+     * removes thread specific data values
+     */
     fun resetCucumberEnvironment() {
         System.clearProperty(SANITY_CHECK)
         System.clearProperty(SECURITY_TOKEN)
         System.clearProperty(TEST_USER)
         CUCUMBER_TESTS.remove()
         INGRESS_FOR_APP.remove()
+        BidragCucumberSingletons.removeRunStats()
+        RestTjenesteForApplikasjon.removeAll()
+        FellesEgenskaperService.fjernResttjenester()
+        PrefiksetJournalpostIdForHendelse.fjernIdForHendelser()
     }
 
     fun isNoContextPathForApp(applicationName: String) = if (fetchPropertyOrEnvironment(NO_CONTEXT_PATH_FOR_APPS) == null) {

--- a/src/main/kotlin/no/nav/bidrag/cucumber/RestTjenesteForApplikasjon.kt
+++ b/src/main/kotlin/no/nav/bidrag/cucumber/RestTjenesteForApplikasjon.kt
@@ -46,6 +46,10 @@ internal object RestTjenesteForApplikasjon {
         return RestTjeneste.ResttjenesteMedBaseUrl(httpHeaderRestTemplate, applicationUrl)
     }
 
+    fun removeAll() {
+        REST_TJENESTE_FOR_APPLIKASJON.removeAll()
+    }
+
     private class BaseUrlTemplateHandler(val baseUrl: String) : UriTemplateHandler {
         override fun expand(uriTemplate: String, uriVariables: MutableMap<String, *>): URI {
             if (uriVariables.isNotEmpty()) {
@@ -93,6 +97,10 @@ internal object RestTjenesteForApplikasjon {
             }
 
             return REST_TJENESTER.get()
+        }
+
+        fun removeAll() {
+            REST_TJENESTER.remove()
         }
     }
 }

--- a/src/main/kotlin/no/nav/bidrag/cucumber/ScenarioManager.kt
+++ b/src/main/kotlin/no/nav/bidrag/cucumber/ScenarioManager.kt
@@ -2,95 +2,99 @@ package no.nav.bidrag.cucumber
 
 import io.cucumber.java8.Scenario
 import no.nav.bidrag.commons.CorrelationId
+import no.nav.bidrag.cucumber.model.BidragCucumberSingletons
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-class ScenarioManager {
-    companion object {
-        @JvmStatic
-        private val LOGGER = LoggerFactory.getLogger(ScenarioManager::class.java)
+object ScenarioManager {
+    @JvmStatic
+    private val LOGGER = LoggerFactory.getLogger(ScenarioManager::class.java)
 
-        private lateinit var correlationIdForScenario: String
-        private var scenario: Scenario? = null
+    private lateinit var correlationIdForScenario: String
+    private var scenario: Scenario? = null
 
-        fun use(scenario: Scenario) {
-            this.scenario = scenario
-            initCorrelationId()
-        }
+    fun use(scenario: Scenario) {
+        this.scenario = scenario
+        initCorrelationId()
+        BidragCucumberSingletons.holdTestMessage("Starting ${BidragCucumberSingletons.scenarioMessage(scenario)}")
+    }
 
-        internal fun initCorrelationId() {
-            correlationIdForScenario = createCorrelationIdValue()
-            MDC.put(CORRELATION_ID, correlationIdForScenario)
-        }
+    internal fun initCorrelationId() {
+        correlationIdForScenario = createCorrelationIdValue()
+        MDC.put(CORRELATION_ID, correlationIdForScenario)
+    }
 
-        fun reset(scenario: Scenario) {
-            val noScenario = scenario.name != null && scenario.name.isNotBlank()
-            val scenarioString = if (noScenario) "'${scenario.name}'" else "scenario in ${scenario.uri}"
+    fun reset(scenario: Scenario) {
+        BidragCucumberSingletons.holdTestMessage("Finished ${BidragCucumberSingletons.scenarioMessage(scenario)}")
+        BidragCucumberSingletons.addRunStats(scenario)
+        this.scenario = null
+        resetCorrelationId()
+    }
 
-            LOGGER.info("Finished $scenarioString")
+    private fun resetCorrelationId() {
+        correlationIdForScenario = createCorrelationIdValue("outside-scenario")
+        MDC.clear()
+    }
 
-            this.scenario = null
-            correlationIdForScenario = createCorrelationIdValue("outside-scenario")
-            MDC.clear()
-        }
+    private fun createCorrelationIdValue(label: String = "bcc"): String {
+        return CorrelationId.generateTimestamped(label).get()
+    }
 
-        private fun createCorrelationIdValue(label: String = "bcc"): String {
-            return CorrelationId.generateTimestamped(label).get()
-        }
+    fun log(message: String) {
+        log(null, message, LogLevel.INFO)
+    }
 
-        fun log(message: String) {
-            log(null, message, LogLevel.INFO)
-        }
+    fun log(messageTitle: String?, message: String) {
+        log(messageTitle, message, LogLevel.INFO)
+    }
 
-        fun log(messageTitle: String?, message: String) {
-            log(messageTitle, message, LogLevel.INFO)
-        }
+    private fun log(messageTitle: String?, message: String, logLevel: LogLevel) {
+        if (scenario != null) {
+            val logLevelMessage = logLevel.produceLogMessage(messageTitle, message)
 
-        private fun log(messageTitle: String?, message: String, logLevel: LogLevel) {
-            if (scenario != null) {
-                scenario!!.log(logLevel.produceLogMessage(messageTitle, message))
-            } else {
-                when (logLevel) {
-                    LogLevel.INFO -> {
-                        LOGGER.info("Outside scenario: $message")
-                    }
+            BidragCucumberSingletons.holdTestMessage(logLevelMessage)
+            scenario!!.log(logLevelMessage)
+        } else {
+            when (logLevel) {
+                LogLevel.INFO -> {
+                    LOGGER.info("Outside scenario: $message")
+                }
 
-                    LogLevel.ERROR -> {
-                        LOGGER.error("Outside scenario: $message")
-                    }
+                LogLevel.ERROR -> {
+                    LOGGER.error("Outside scenario: $message")
                 }
             }
         }
+    }
 
-        fun createQueryLinkForCorrelationId(): String {
-            val pattern = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-            val date = LocalDate.now().format(pattern)
+    fun createQueryLinkForCorrelationId(): String {
+        val pattern = DateTimeFormatter.ofPattern("yyyy-MM-dd")
+        val date = LocalDate.now().format(pattern)
 
-            val time = "time:(from:%27${date}T00:00:00.000Z%27,to:%27${date}T23:59:59.999Z%27)"
-            val columns = "columns:!(message,level,application)"
-            val index = "index:%2796e648c0-980a-11e9-830a-e17bbd64b4db%27"
-            val query = "query:(language:lucene,query:'x_correlationId:%22$correlationIdForScenario%22')"
-            val sort = "sort:!(!(%27@timestamp%27,desc))"
+        val time = "time:(from:%27${date}T00:00:00.000Z%27,to:%27${date}T23:59:59.999Z%27)"
+        val columns = "columns:!(message,level,application)"
+        val index = "index:%2796e648c0-980a-11e9-830a-e17bbd64b4db%27"
+        val query = "query:(language:lucene,query:'x_correlationId:%22$correlationIdForScenario%22')"
+        val sort = "sort:!(!(%27@timestamp%27,desc))"
 
-            return "https://logs.adeo.no/app/kibana#/discover?_g=($time)&_a=($columns,$index,interval:auto,$query,$sort)"
-        }
+        return "https://logs.adeo.no/app/kibana#/discover?_g=($time)&_a=($columns,$index,interval:auto,$query,$sort)"
+    }
 
-        fun createCorrelationIdLinkTitle() = "Link for correlation-id, $correlationIdForScenario"
-        fun getCorrelationIdForScenario() = correlationIdForScenario
-        fun errorLog(message: String) = log(null, message, LogLevel.ERROR)
+    fun createCorrelationIdLinkTitle() = "Link for correlation-id, $correlationIdForScenario"
+    fun getCorrelationIdForScenario() = correlationIdForScenario
+    fun errorLog(message: String) = log(null, message, LogLevel.ERROR)
 
-        private enum class LogLevel {
-            INFO, ERROR;
+    private enum class LogLevel {
+        INFO, ERROR;
 
-            fun produceLogMessage(messageTitle: String?, message: String) = when (this) {
-                INFO -> {
-                    if (messageTitle != null) "$messageTitle:\n$message\n" else "$message\n"
-                }
-                ERROR -> {
-                    if (messageTitle != null) "An error accured!\n$messageTitle:\n$message\n" else "An error occured!\n$message\n"
-                }
+        fun produceLogMessage(messageTitle: String?, message: String) = when (this) {
+            INFO -> {
+                if (messageTitle != null) "$messageTitle:\n$message\n" else message
+            }
+            ERROR -> {
+                if (messageTitle != null) "An error accured!\n$messageTitle:\n$message\n" else "An error occured!\n$message"
             }
         }
     }

--- a/src/main/kotlin/no/nav/bidrag/cucumber/cloud/FellesEgenskaperService.kt
+++ b/src/main/kotlin/no/nav/bidrag/cucumber/cloud/FellesEgenskaperService.kt
@@ -25,6 +25,7 @@ object FellesEgenskaperService {
     }
 
     fun hentRestTjeneste() = RESTTJENESTER.get() ?: throw IllegalStateException("Ingen resttjeneste for tråd. Har du satt opp ingressesForApps?")
+    fun fjernResttjenester() = RESTTJENESTER.remove()
 
     data class Assertion(val message: String, val value: Any?, val expectation: Any?)
 }

--- a/src/main/kotlin/no/nav/bidrag/cucumber/cloud/arbeidsflyt/ArbeidsflytEgenskaperEndreFagomradeService.kt
+++ b/src/main/kotlin/no/nav/bidrag/cucumber/cloud/arbeidsflyt/ArbeidsflytEgenskaperEndreFagomradeService.kt
@@ -32,7 +32,7 @@ object ArbeidsflytEgenskaperEndreFagomradeService {
         val journalpostHendelse = JournalpostHendelse(detaljer, hendelse, tema)
 
         BidragCucumberSingletons.hendelseProducer?.publish(journalpostHendelse)
-            ?: LOGGER.warn(
+            ?: LOGGER.info(
                 "Cannot publish $hendelse ${
                     if (Environment.isSanityCheck) {
                         "while running sanity check!"

--- a/src/main/kotlin/no/nav/bidrag/cucumber/cloud/arbeidsflyt/PrefiksetJournalpostIdForHendelse.kt
+++ b/src/main/kotlin/no/nav/bidrag/cucumber/cloud/arbeidsflyt/PrefiksetJournalpostIdForHendelse.kt
@@ -5,7 +5,11 @@ import java.util.EnumMap
 class PrefiksetJournalpostIdForHendelse {
     companion object {
         @JvmStatic
-        internal val PREFIKSET_ID_FOR_HENDELER = ThreadLocal<MutableMap<Hendelse, MutableMap<String, String>>>()
+        private val PREFIKSET_ID_FOR_HENDELER = ThreadLocal<MutableMap<Hendelse, MutableMap<String, String>>>()
+
+        fun fjernIdForHendelser() {
+            PREFIKSET_ID_FOR_HENDELER.remove()
+        }
     }
 
     fun opprett(hendelse: Hendelse, journalpostId: Long, tema: String): String {

--- a/src/main/kotlin/no/nav/bidrag/cucumber/model/CucumberTestsDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/cucumber/model/CucumberTestsDto.kt
@@ -99,7 +99,14 @@ data class CucumberTestsDto(
             return ""
         }
 
-        return if (tagsFromIngresses.isBlank()) transformToString(tags) else " or ${transformToString(tags)}"
+        val uniqueTags = tags
+            .filterNot { tagsFromIngresses.contains(it) }
+
+        if (uniqueTags.isEmpty()) {
+            return ""
+        }
+
+        return if (tagsFromIngresses.isBlank()) transformToString(uniqueTags) else " or ${transformToString(uniqueTags)}"
     }
 
     internal fun initCucumberEnvironment() {

--- a/src/main/kotlin/no/nav/bidrag/cucumber/model/CucumberTestsDto.kt
+++ b/src/main/kotlin/no/nav/bidrag/cucumber/model/CucumberTestsDto.kt
@@ -110,7 +110,6 @@ data class CucumberTestsDto(
     }
 
     internal fun initCucumberEnvironment() {
-        Environment.resetCucumberEnvironment()
         Environment.initCucumberEnvironment(this)
     }
 
@@ -122,7 +121,9 @@ data class CucumberTestsDto(
 
     private fun isNotEqual(dtoValue: Any?, envValue: Any?) = dtoValue != envValue
 
-    private fun warningForDifference(name: String, property: Any?, envValue: Any?) = LOGGER.warn(
-        "$property vs $envValue: (${this.javaClass.simpleName}/$name vs ${Environment::class.java.simpleName}.$name)"
-    )
+    private fun warningForDifference(name: String, property: Any?, envValue: Any?) {
+        if (property == null && envValue != "null" || property != "null" && envValue == null) {
+            LOGGER.warn("$property vs $envValue: (${this.javaClass.simpleName}.$name vs ${Environment::class.java.simpleName} - $name)")
+        }
+    }
 }

--- a/src/main/kotlin/no/nav/bidrag/cucumber/model/TestMessagesHolder.kt
+++ b/src/main/kotlin/no/nav/bidrag/cucumber/model/TestMessagesHolder.kt
@@ -1,0 +1,33 @@
+package no.nav.bidrag.cucumber.model
+
+import org.slf4j.LoggerFactory
+
+class TestMessagesHolder {
+    companion object {
+        @JvmStatic
+        private val LOGGER = LoggerFactory.getLogger(TestMessagesHolder::class.java)
+
+        @JvmStatic
+        private val TEST_MESSAGES_FOR_THREAD = ThreadLocal<MutableList<String>?>()
+    }
+
+    fun fetchTestMessages(): String {
+        val joinToString = hentMeldinger().joinToString(separator = "\n")
+        TEST_MESSAGES_FOR_THREAD.remove()
+
+        return joinToString
+    }
+
+    internal fun hold(testMessage: String) {
+        hentMeldinger().add(testMessage)
+        LOGGER.info(testMessage)
+    }
+
+    private fun hentMeldinger(): MutableList<String> {
+        if (TEST_MESSAGES_FOR_THREAD.get() == null) {
+            TEST_MESSAGES_FOR_THREAD.set(ArrayList())
+        }
+
+        return TEST_MESSAGES_FOR_THREAD.get()!!
+    }
+}

--- a/src/main/kotlin/no/nav/bidrag/cucumber/spring-config.kt
+++ b/src/main/kotlin/no/nav/bidrag/cucumber/spring-config.kt
@@ -9,6 +9,7 @@ import no.nav.bidrag.commons.web.HttpHeaderRestTemplate
 import no.nav.bidrag.cucumber.aop.ExceptionLoggerAspect
 import no.nav.bidrag.cucumber.aop.TestFailedAdvice
 import no.nav.bidrag.cucumber.hendelse.JournalpostKafkaHendelseProducer
+import no.nav.bidrag.cucumber.model.TestMessagesHolder
 import no.nav.bidrag.cucumber.model.SuppressStackTraceText
 import no.nav.bidrag.cucumber.sikkerhet.TokenProvider
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory
@@ -22,8 +23,6 @@ import org.springframework.context.annotation.Scope
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.web.client.RestTemplate
-import org.springframework.web.util.UriTemplateHandler
-import java.net.URI
 import java.security.cert.X509Certificate
 
 @Configuration
@@ -70,6 +69,9 @@ class SpringConfig {
 
         return requestFactory
     }
+
+    @Bean
+    fun testMessagesHolder() = TestMessagesHolder()
 }
 
 @Configuration

--- a/src/test/kotlin/no/nav/bidrag/cucumber/RestTjenesteTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/cucumber/RestTjenesteTest.kt
@@ -2,6 +2,7 @@ package no.nav.bidrag.cucumber
 
 import no.nav.bidrag.cucumber.model.CucumberTestsDto
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import org.mockito.Mockito.anyString
@@ -16,6 +17,11 @@ import org.springframework.util.LinkedMultiValueMap
 import org.springframework.web.client.RestTemplate
 
 internal class RestTjenesteTest {
+
+    @BeforeEach
+    fun `reset Cucumber environment`() {
+        Environment.resetCucumberEnvironment()
+    }
 
     @Test
     fun `gitt INGRESSES_FOR_APPS med verdi for applikasjon, skal RestTjeneste konfigureres med denne verdien`() {

--- a/src/test/kotlin/no/nav/bidrag/cucumber/controller/CucumberControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/cucumber/controller/CucumberControllerIntegrationTest.kt
@@ -3,6 +3,7 @@ package no.nav.bidrag.cucumber.controller
 import no.nav.bidrag.cucumber.BidragCucumberCloudLocal
 import no.nav.bidrag.cucumber.TestUtil.assumeThatActuatorHealthIsRunning
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -83,7 +84,11 @@ internal class CucumberControllerIntegrationTest {
             String::class.java
         )
 
-        assertThat(testResponse.body).`as`("body").contains("Scenarios").contains("Steps").contains("passed")
+        val softly = SoftAssertions()
+        softly.assertThat(testResponse.body).`as`("body").contains("Scenarios")
+        softly.assertThat(testResponse.body).`as`("body").contains("Failed")
+        softly.assertThat(testResponse.body).`as`("body").contains("Passed")
+        softly.assertAll()
     }
 
     @Test

--- a/src/test/kotlin/no/nav/bidrag/cucumber/controller/CucumberControllerRestTemplateMockBeanTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/cucumber/controller/CucumberControllerRestTemplateMockBeanTest.kt
@@ -3,11 +3,11 @@ package no.nav.bidrag.cucumber.controller
 import no.nav.bidrag.commons.web.HttpHeaderRestTemplate
 import no.nav.bidrag.cucumber.BidragCucumberCloudLocal
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertAll
 import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatcher
 import org.mockito.kotlin.any
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.eq
@@ -59,7 +59,34 @@ class CucumberControllerRestTemplateMockBeanTest {
 
         assertAll(
             { assertThat(testResponse.statusCode).`as`("status code").isEqualTo(HttpStatus.NOT_ACCEPTABLE) },
-            { assertThat(urlCaptor.value).`as`("endpoint url").isEqualTo("/sak/1900000")           }
+            { assertThat(urlCaptor.value).`as`("endpoint url").isEqualTo("/sak/1900000") }
         )
+    }
+
+    @Test
+    fun `skal trekke ut logginnslag til egen bønne som brukes i http resultat`() {
+        val headers = HttpHeaders()
+        headers.contentType = MediaType.APPLICATION_JSON
+
+        val testResponse = testRestTemplate.postForEntity(
+            "/run",
+            HttpEntity(
+                """
+                {
+                  "testUsername":"z992903","ingressesForApps":[
+                    "https://bidrag-sak-feature.dev-fss-pub.nais.io@bidrag-sak"
+                  ]
+                }
+                """.trimMargin().trim(), headers
+            ),
+            String::class.java
+        )
+
+        val testMessages = testResponse.body ?: "Ingen body i response: $testResponse"
+
+        val softly = SoftAssertions()
+        softly.assertThat(testMessages).contains("Link")
+        softly.assertThat(testMessages).contains("Scenario")
+        softly.assertAll()
     }
 }

--- a/src/test/kotlin/no/nav/bidrag/cucumber/model/CucumberTestsDtoTest.kt
+++ b/src/test/kotlin/no/nav/bidrag/cucumber/model/CucumberTestsDtoTest.kt
@@ -2,7 +2,6 @@ package no.nav.bidrag.cucumber.model
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
-import org.assertj.core.api.SoftAssertions
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
@@ -56,5 +55,12 @@ internal class CucumberTestsDtoTest {
 
         assertThatIllegalStateException().isThrownBy { cucumberTestsDto.fetchTags() }
             .withMessage("Ingen tags er oppgitt. Bruk liste med tags eller liste med ingresser som ikke har prefiksen 'no-tag:' etter @")
+    }
+
+    @Test
+    fun `skal ikke hente ut tags dobbelt opp`() {
+        val cucumberTestsDto = CucumberTestsDto(ingressesForApps = listOf("https://somewhere.out.there@bidrag-sak"), tags = listOf("@bidrag-sak"))
+
+        assertThat(cucumberTestsDto.fetchTags()).`as`("cucumberTests.fetchTags").isEqualTo("(@bidrag-sak and not @ignored)")
     }
 }


### PR DESCRIPTION
- Environment will always fetch unique tags
- System.out cannot be read for single thread
- created TestMessagesHolder: Messages produced by test is kept for thread only
- created Environment.RunStats
- ScenarioManager, from class -> object
- TestMessagesHolder.kt is bean in spring context
- removes ThreadLocals:
  - RunStats.remove()
  - RestTjenesteForApplikasjon.removeAll()
  - FellesEgenskaperService.fjernResttjenester()
  - PrefiksetJournalpostIdForHendelse.fjernIdForHendelser()
  - TestMessagesHolder.fetchTestMessages()
- do not log warning on camparison between string null and value null
- log do not publish message: warn -> info